### PR TITLE
Upgrade postgresql-jdbc to 42.7.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
         <postgresql.container>mirror.gcr.io/postgres:${postgresql.version}</postgresql.container>
         <aurora-postgresql.version>16.8</aurora-postgresql.version>
         <aws-jdbc-wrapper.version>2.5.6</aws-jdbc-wrapper.version>
-        <postgresql-jdbc.version>42.7.5</postgresql-jdbc.version>
+        <postgresql-jdbc.version>42.7.7</postgresql-jdbc.version>
         <mariadb.version>11.4</mariadb.version>
         <mariadb.container>mirror.gcr.io/mariadb:${mariadb.version}</mariadb.container>
         <mariadb-jdbc.version>3.5.2</mariadb-jdbc.version>


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
Upgrade PostgreSQL-JDBC to 42.7.7 to address CVE-2025-49146

Context:
https://nvd.nist.gov/vuln/detail/CVE-2025-49146
https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-hq9p-pm7w-8p54
https://github.com/pgjdbc/pgjdbc/commit/9217ed16cb2918ab1b6b9258ae97e6ede244d8a0